### PR TITLE
oauth_version parameter should be optional

### DIFF
--- a/src/JacobKiers/OAuth/Request/Request.php
+++ b/src/JacobKiers/OAuth/Request/Request.php
@@ -157,7 +157,6 @@ class Request implements RequestInterface
     ) {
         $parameters = ($parameters) ? $parameters : array();
         $defaults = array(
-            'oauth_version' => Request::$version,
             'oauth_nonce' => Request::generateNonce(),
             'oauth_timestamp' => Request::generateTimestamp(),
             'oauth_consumer_key' => $consumer->getKey());


### PR DESCRIPTION
`oauth_version` parameter should be optional.

@see: http://oauth.net/core/1.0a/#rfc.section.6.1.1 and http://oauth.net/core/1.0a/#rfc.section.6.3.1
