### PR TITLE
Add load balancer support

### DIFF
--- a/src/JacobKiers/OAuth/Request/Request.php
+++ b/src/JacobKiers/OAuth/Request/Request.php
@@ -93,10 +93,17 @@ class Request implements RequestInterface
     public static function fromRequest($http_method = null, $http_url = null, $parameters = null)
     {
         $scheme = (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] != 'on') ? 'http' : 'https';
+        $scheme = isset($_SERVER['HTTP_X_FORWARDED_PROTO'])
+            ? $_SERVER['HTTP_X_FORWARDED_PROTO']
+            : $scheme;
+        $port = isset($_SERVER['HTTP_X_FORWARDED_PORT'])
+            ? $_SERVER['HTTP_X_FORWARDED_PORT']
+            : $_SERVER['SERVER_PORT'];
+
         $http_url = ($http_url) ? $http_url : $scheme .
             '://' . $_SERVER['HTTP_HOST'] .
             ':' .
-            $_SERVER['SERVER_PORT'] .
+            $port .
             $_SERVER['REQUEST_URI'];
         $http_method = ($http_method) ? $http_method : $_SERVER['REQUEST_METHOD'];
 


### PR DESCRIPTION
Add load balancer support using non-standard X-Forwarded headers. 

Basically it adds support for AWS Elastic Load Balancer. See docs here [x-forwarded-headers](https://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/TerminologyandKeyConcepts.html#x-forwarded-headers) and a proposed standard [rfc7239](http://tools.ietf.org/html/rfc7239) which varies a bit since it does not seem to add support for the `X-Forwarded-Port` header.

I also confirm that this does work behind a ELB that does SSL termination.
