### PR TITLE
Fix interface inheritance (#7)

### DIFF
--- a/src/JacobKiers/OAuth/SignatureMethod/SignatureMethod.php
+++ b/src/JacobKiers/OAuth/SignatureMethod/SignatureMethod.php
@@ -28,28 +28,6 @@ use \JacobKiers\OAuth\Request\RequestInterface;
 abstract class SignatureMethod implements SignatureMethodInterface
 {
     /**
-     * Return the name of the Signature Method (ie HMAC-SHA1).
-     *
-     * @return string
-     */
-    abstract public function getName();
-
-    /**
-     * Build up the signature.
-     *
-     * NOTE: The output of this function MUST NOT be urlencoded.
-     * the encoding is handled in OAuthRequest when the final
-     * request is serialized.
-     *
-     * @param JacobKiers\OAuth\Request\RequestInterface $request
-     * @param JacobKiers\OAuth\Consumer\ConsumerInterface        $consumer
-     * @param JacobKiers\OAuth\Token\TokenInterface     $token
-     *
-     * @return string
-     */
-    abstract public function buildSignature(RequestInterface $request, ConsumerInterface $consumer, TokenInterface $token = null);
-
-    /**
      * Get the signature key, made up of consumer and optionally token shared secrets.
      *
      * @param JacobKiers\OAuth\Consumer\ConsumerInterface    $consumer


### PR DESCRIPTION
Interface inheritance is not possible before PHP 5.3.9. That is an
artefact of PHP bug 43200 (https://bugs.php.net/43200).

Since the composer.json states that the PHP versions >= 5.3.0 are
supported, we have to maintain compatibility with PHP 5.3.X.

Fixes: #7